### PR TITLE
Update support links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Unofficial Twilio Authy Flatpak wrapper package.
 
 NOTE: This wrapper is not verified by, affiliated with, or supported by Authy nor Twilio.
 
-IMPORTANT: This app will reach their [End-of-Life in August 2024](https://support.authy.com/hc/en-us/articles/17592416719003-Authy-for-Desktop-End-of-Life-EOL-).
+IMPORTANT: This app will reach their [End-of-Life in August 2024](https://help.twilio.com/articles/19753631228315).
 
 <a href='https://flathub.org/apps/details/com.authy.Authy'><img width='120' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a>
 

--- a/com.authy.Authy.metainfo.xml
+++ b/com.authy.Authy.metainfo.xml
@@ -13,7 +13,7 @@
     </description>
     <url type="homepage">https://authy.com/</url>
     <url type="help">https://authy.com/help/</url>
-    <url type="faq">https://support.authy.com/hc/en-us/categories/360000616253-Authy-Application</url>
+    <url type="faq">https://help.twilio.com/sections/19752334096411</url>
     <screenshots>
         <screenshot type="default">
             <image type="source">https://authy.com/wp-content/uploads/Authy-Screenshot-1.png</image>


### PR DESCRIPTION
The old support.authy.com site will no longer be available after January 15, 2024.
More info [here](https://support.authy.com/hc/en-us/articles/21225037125147-Twilio-s-New-Customer-Help-Center-for-Authy-Users).