### PR TITLE
Mark as flathub EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,4 @@ Unofficial Twilio Authy Flatpak wrapper package.
 
 NOTE: This wrapper is not verified by, affiliated with, or supported by Authy nor Twilio.
 
-IMPORTANT: This app will reach their [End-of-Life on March 19, 2024](https://help.twilio.com/articles/22771146070299-User-guide-End-of-Life-EOL-for-Twilio-Authy-Desktop-app).
-
-<a href='https://flathub.org/apps/details/com.authy.Authy'><img width='120' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a>
-
-## Permissions
-
-- GUI: x11, dri, ipc
-- Notifications: org.freedesktop.Notifications, org.kde.StatusNotifierWatcher
-- Sound: pulseaudio
-- Network: to allow login to the service
+IMPORTANT: This app has reached their [End-of-Life on March 19, 2024](https://help.twilio.com/articles/22771146070299-User-guide-End-of-Life-EOL-for-Twilio-Authy-Desktop-app).

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
-  "automerge-flathubbot-prs": true,
+  "end-of-life": "The Authy Desktop app have their End-of-Life. It is recommended to switch to use their mobile apps instead or other equivalent desktop apps.",
   "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
This app had reached their [End-of-Life on March 19, 2024](https://help.twilio.com/articles/22771146070299-User-guide-End-of-Life-EOL-for-Twilio-Authy-Desktop-app).

It seams today they removed if from the [snap store](https://snapcraft.io/authy).

This PR [marks as EOL for flathub](https://docs.flathub.org/docs/for-app-authors/maintenance/#end-of-life).